### PR TITLE
防止创建install目录报错

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -185,7 +185,7 @@ Linux)
 				
 			# 获取wavm-linux
 			cd deps
-			mkdir install
+			mkdir -p install
 			cd install 
 			wget https://github.com/walden01/prototype_deps/releases/download/deps/wavm-linux.tar.gz
 			tar -xzvf ./wavm-linux.tar.gz


### PR DESCRIPTION
创建install目录时，如果已存在，现在不会报错